### PR TITLE
Allow configuration from ENV and add round_frequency configuration

### DIFF
--- a/sweep_tool/requirements.txt
+++ b/sweep_tool/requirements.txt
@@ -14,7 +14,7 @@ py-ed25519-bindings==1.0.1
 py-sr25519-bindings==0.1.4
 pycryptodome==3.13.0
 requests==2.27.1
-scalecodec==1.0.28
+scalecodec>=1.0.35
 schedule==1.1.0
 six==1.16.0
 substrate-interface==1.1.7

--- a/sweep_tool/sweep.py
+++ b/sweep_tool/sweep.py
@@ -15,7 +15,7 @@ def run_sweep():
   decimals = 10**(substrate.properties["tokenDecimals"])
 
   # Get current block
-  current_block = substrate.get_block(ignore_decoding_errors=True)
+  current_block = substrate.get_block()
   current_block_number = current_block["header"]["number"]
 
   if current_block_number >= next_sweep:

--- a/sweep_tool/sweep.py
+++ b/sweep_tool/sweep.py
@@ -50,7 +50,7 @@ def run_sweep():
     # Schedule next sweep, in the middle of the next round
     current_round = substrate.query(module="ParachainStaking",storage_function="Round")
     round_length = current_round.value["length"]
-    next_sweep = current_round.value["first"] + int(1.5 * round_length)
+    next_sweep = current_round.value["first"] + int(0.5 * round_length) + int(config["round_frequency"] * round_length)
 
     logging.info(f"  Next sweep scheduled for block {next_sweep}")
 
@@ -125,6 +125,8 @@ if __name__ == "__main__":
     config["endpoint"] = os.environ["SWEEP_ENDPOINT"]
   if "SWEEP_FROM_ADDRESSES" in os.environ:
     config["from_addresses"] = os.environ["SWEEP_FROM_ADDRESSES"].split(",")
+  if "SWEEP_ROUND_FREQUENCY" in os.environ:
+    config["round_frequency"] = int(os.environ["SWEEP_ROUND_FREQUENCY"])
 
   # Schedule the sweep for every 10 minutes, but only actualy does anything if we're at (or past) the correct block
   schedule.every(10).minutes.do(run_sweep)

--- a/sweep_tool/sweep.py
+++ b/sweep_tool/sweep.py
@@ -15,7 +15,7 @@ def run_sweep():
   decimals = 10**(substrate.properties["tokenDecimals"])
 
   # Get current block
-  current_block = substrate.get_block()
+  current_block = substrate.get_block(ignore_decoding_errors=True)
   current_block_number = current_block["header"]["number"]
 
   if current_block_number >= next_sweep:
@@ -115,7 +115,7 @@ if __name__ == "__main__":
   if args.config:
     with open(args.config) as f:
       config = json.loads(f.read())
-  
+
   # Load config from ENV
   if "SWEEP_PROXY_MNEMONIC" in os.environ:
     config["proxy_mnemonic"] = os.environ["SWEEP_PROXY_MNEMONIC"]


### PR DESCRIPTION
Environment variables:
SWEEP_PROXY_MNEMONIC
SWEEP_TO_ADDRESS
SWEEP_ENDPOINT
SWEEP_FROM_ADDRESSES
SWEEP_ROUND_FREQUENCY

Round frequency dictates how often (in number of rounds) the sweep is executed. Useful to save on transaction fees
